### PR TITLE
Update name of etcherPro-fleet-sw repo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -36,7 +36,7 @@
     "**/Dockerfile.template"
   ],
   "repositories": [
-    "balena-io-hardware/etcherpro-fleet"
+    "balena-io-hardware/etcherPro-fleet-sw"
   ],
   "packageRules": [
     {


### PR DESCRIPTION
Repo renames need to be manually updated, because Renovate [doesn't redirect](https://github.com/renovatebot/renovate/discussions/19159).